### PR TITLE
Fix layout issue for  RTL languages

### DIFF
--- a/TaggerKit/Classes/Source/CollectionView/CollectionViewCell/TKTagCell.swift
+++ b/TaggerKit/Classes/Source/CollectionView/CollectionViewCell/TKTagCell.swift
@@ -132,7 +132,10 @@ class TKTagCell: UICollectionViewCell {
 							   attribute: .centerY,
 							   multiplier: 1.0,
 							   constant: 0),
-			
+
+        let isRTL = UIApplication.shared.userInterfaceLayoutDirection == .rightToLeft
+        let  constraintButtonTo: Attribute = isRTL ? .leading : .trailing
+
 			NSLayoutConstraint(item: button,
 							   attribute: .width,
 							   relatedBy: .equal,
@@ -148,10 +151,10 @@ class TKTagCell: UICollectionViewCell {
 							   multiplier: 1.0,
 							   constant: 28),
 			NSLayoutConstraint(item: button,
-							   attribute: .trailing,
+							   attribute: constraintButtonTo,
 							   relatedBy: .equal,
 							   toItem: self,
-							   attribute: .trailing,
+							   attribute: constraintButtonTo,
 							   multiplier: 1.0,
 							   constant: 0),
 			NSLayoutConstraint(item: button,


### PR DESCRIPTION
Instead of this
https://www.dropbox.com/s/95wrekuc0xbbrg6/Screen%20Shot%202021-03-25%20at%2011.19.42%20AM.png?dl=0

I fixed it to be like this in RTL languages
 https://www.dropbox.com/s/3pkkt97undx0ekk/Screen%20Shot%202021-03-25%20at%2011.20.58%20AM.png?dl=0